### PR TITLE
Fixed decimalSeparator for locale with "," symbol

### DIFF
--- a/Sources/NPBaseConfig.swift
+++ b/Sources/NPBaseConfig.swift
@@ -33,6 +33,8 @@ open class NPBaseConfig<T>: ObservableObject
 
     // MARK: - Public Properties
 
+    public var decimalCharacter: Character { Locale.current.decimalSeparator?.first ?? "." }
+
     public var showDecimalPoint: Bool { false }
 
     public var stringValue: String {

--- a/Sources/NPDecimalConfig.swift
+++ b/Sources/NPDecimalConfig.swift
@@ -52,7 +52,7 @@ public final class NPDecimalConfig: NPBaseConfig<Decimal> {
 
     override public func decimalPointAction() -> Bool {
         guard decimalPointIndex == nil else { return false }
-        sValue.append(".")
+        sValue.append(decimalCharacter)
 
         return true
     }
@@ -82,6 +82,6 @@ public final class NPDecimalConfig: NPBaseConfig<Decimal> {
     }
 
     internal var decimalPointIndex: String.Index? {
-        sValue.firstIndex(of: ".")
+        sValue.firstIndex(of: decimalCharacter)
     }
 }

--- a/Sources/NPFloatConfig.swift
+++ b/Sources/NPFloatConfig.swift
@@ -54,7 +54,7 @@ public final class NPFloatConfig<T>: NPBaseConfig<T>
 
     override public func decimalPointAction() -> Bool {
         guard decimalPointIndex == nil else { return false }
-        sValue.append(".")
+        sValue.append(decimalCharacter)
 
         return true
     }
@@ -85,6 +85,6 @@ public final class NPFloatConfig<T>: NPBaseConfig<T>
     }
 
     internal var decimalPointIndex: String.Index? {
-        sValue.firstIndex(of: ".")
+        sValue.firstIndex(of: decimalCharacter)
     }
 }

--- a/Sources/NumberPad.swift
+++ b/Sources/NumberPad.swift
@@ -106,7 +106,7 @@ public struct NumberPad<T>: View
 
     private var decimalPoint: some View {
         Button(action: decimalPointAction) {
-            Text(".")
+            Text(String(config.decimalCharacter))
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }


### PR DESCRIPTION
The previous solution did not work for locales that use "," as a separator. NumberFormatter could not get a number from a string with a dot